### PR TITLE
fix call a non existing method

### DIFF
--- a/Perimeter/BusinessPerimeterManager.php
+++ b/Perimeter/BusinessPerimeterManager.php
@@ -55,7 +55,7 @@ class BusinessPerimeterManager extends AbstractBusinessPerimeterManager
      */
     public function deleteUserPerimeters(UserInterface $user)
     {
-        $this->perimeterManager->deleteUserPerimeters($user);
+        // @todo Implement the functionality
     }
 
     /**


### PR DESCRIPTION
When we delete a user in NMM that has TimeTable, there is an error because perimeterManager does not have deleteUserPerimeters method