### PR TITLE
Adding calendar list item into the menu

### DIFF
--- a/Menu/MenuManager.php
+++ b/Menu/MenuManager.php
@@ -21,8 +21,7 @@ class MenuManager
     public function __construct(
         UserManager $userManager,
         Container $container
-    )
-    {
+    ) {
         $this->userManager = $userManager;
         $this->container = $container;
         $this->requestStack = $container->get('request_stack');
@@ -110,6 +109,12 @@ class MenuManager
             $menu[] = $seasons;
         }
 
+        $calendars = new BusinessMenuItem();
+        $calendars->setName($translator->trans('menu.calendar_list'));
+        $calendars->setRoute('canal_tp_mtt_calendar_list');
+        $calendars->setRoutePatternForHighlight(['/.*_calendars.*/', ]);
+        $menu[] = $calendars;
+
         $edit = new BusinessMenuItem();
         $edit->setName($translator->trans('menu.edit_timetables'));
         $edit->setRoute('canal_tp_mtt_stop_point_list_defaults');
@@ -117,7 +122,7 @@ class MenuManager
             'externalNetworkId' => $currentNetwork
         ));
 
-        $edit->setRoutePatternForHighlight(array('/.*_stop_point_.*/', '/.*_calendar_.*/', '/.*_timetable_.*/'));
+        $edit->setRoutePatternForHighlight(array('/.*_stop_point_.*/', '/.*_calendar\/_.*/', '/.*_timetable_.*/'));
 
         $menu[] = $edit;
 
@@ -175,7 +180,7 @@ class MenuManager
 
             $menu[] = $administration;
         }
-        
+
         return $menu;
     }
 }

--- a/Tests/MenuManagerTest.php
+++ b/Tests/MenuManagerTest.php
@@ -52,7 +52,7 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         $menu = $menuManager->getMenu();
 
         $this->assertInternalType('array', $menu, 'It should return a menu as an array.');
-        $menuItemsCount = 4;
+        $menuItemsCount = 5;
         $this->assertCount(
             $menuItemsCount,
             $menu,
@@ -63,7 +63,7 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         );
 
         $menuItemClass = 'CanalTP\MttBridgeBundle\Menu\BusinessMenuItem';
-        foreach (range(0, 3) as $menuIndex) {
+        foreach (range(0, 4) as $menuIndex) {
             $this->assertInstanceOf(
                 $menuItemClass,
                 $menu[$menuIndex],
@@ -76,6 +76,8 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         }
 
         $menuLabelsAssertions = [
+            'menu.calendar_list' =>
+                'The default menu item should be a label inviting to list calendars.',
             'menu.edit_timetables' =>
                 'The default menu item should be a label inviting to edit timetables.',
             'menu.area_manage' =>


### PR DESCRIPTION
# Description

This PR adds calendar list item into the menu

## Issue (optional)

Issue link: METH-639

## Pull Request type (optional)

This is a new feature

## How to test

Here are the following steps to test this pull request:

- As mtt user calendar item should appear on the right side of season item

## Warning

This PR depends on https://github.com/CanalTP/MttBundle/pull/126

## Team reviewers (optinnal)
@datanel @kun2985 @dvdn @nberard 
