### PR TITLE
Update regexp for calendars

### DIFF
--- a/Menu/MenuManager.php
+++ b/Menu/MenuManager.php
@@ -111,8 +111,8 @@ class MenuManager
 
         $calendars = new BusinessMenuItem();
         $calendars->setName($translator->trans('menu.calendar_list'));
-        $calendars->setRoute('canal_tp_mtt_calendar_list');
-        $calendars->setRoutePatternForHighlight(['/.*_calendars.*/', ]);
+        $calendars->setRoute('canal_tp_mtt_calendars_list');
+        $calendars->setRoutePatternForHighlight(['/.*_calendars_.*/', ]);
         $menu[] = $calendars;
 
         $edit = new BusinessMenuItem();
@@ -122,7 +122,7 @@ class MenuManager
             'externalNetworkId' => $currentNetwork
         ));
 
-        $edit->setRoutePatternForHighlight(array('/.*_stop_point_.*/', '/.*_calendar\/_.*/', '/.*_timetable_.*/'));
+        $edit->setRoutePatternForHighlight(array('/.*_stop_point_.*/', '/.*_calendar_.*/', '/.*_timetable_.*/'));
 
         $menu[] = $edit;
 


### PR DESCRIPTION
# Description

This PR fixes the active menu item of calendar

## Pull Request type (optional)

This is a bug fix

## How to test

Here are the following steps to test this pull request:

- Login as mtt user
- Click on calendar item
- Calendar item should be highlighted
- Click on calendar creation button
- On calendar creation page calendar menu item should stay highlighted

## Warning

This PR depends on https://github.com/CanalTP/MttBundle/issues/127
## Team reviewers (optinnal)

@datanel @kun2985 @dvdn @nberard 