### PR TITLE
removed menu calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor
+composer.lock
+components

--- a/Menu/MenuManager.php
+++ b/Menu/MenuManager.php
@@ -109,12 +109,6 @@ class MenuManager
             $menu[] = $seasons;
         }
 
-        $calendars = new BusinessMenuItem();
-        $calendars->setName($translator->trans('menu.calendar_list'));
-        $calendars->setRoute('canal_tp_mtt_calendars_list');
-        $calendars->setRoutePatternForHighlight(['/.*_calendars_.*/', ]);
-        $menu[] = $calendars;
-
         $edit = new BusinessMenuItem();
         $edit->setName($translator->trans('menu.edit_timetables'));
         $edit->setRoute('canal_tp_mtt_stop_point_list_defaults');

--- a/Tests/MenuManagerTest.php
+++ b/Tests/MenuManagerTest.php
@@ -52,7 +52,7 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         $menu = $menuManager->getMenu();
 
         $this->assertInternalType('array', $menu, 'It should return a menu as an array.');
-        $menuItemsCount = 5;
+        $menuItemsCount = 4;
         $this->assertCount(
             $menuItemsCount,
             $menu,
@@ -63,7 +63,7 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         );
 
         $menuItemClass = 'CanalTP\MttBridgeBundle\Menu\BusinessMenuItem';
-        foreach (range(0, 4) as $menuIndex) {
+        foreach (range(0, 3) as $menuIndex) {
             $this->assertInstanceOf(
                 $menuItemClass,
                 $menu[$menuIndex],
@@ -76,8 +76,6 @@ class MenuManagerTest extends \PHPUnit_Framework_TestCase
         }
 
         $menuLabelsAssertions = [
-            'menu.calendar_list' =>
-                'The default menu item should be a label inviting to list calendars.',
             'menu.edit_timetables' =>
                 'The default menu item should be a label inviting to edit timetables.',
             'menu.area_manage' =>

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,23 @@
             "email": "kevin.ziemianski@canaltp.fr"
         }
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:CanalTP/MttBundle.git"
+        }
+    ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "symfony/dependency-injection": "^2.6",
+        "symfony/http-foundation": "^2.6",
+        "symfony/security": "^2.6",
+        "symfony/translation": "^2.6",
+        "canaltp/mtt-bundle": "^1.0",
+        "canaltp/sam-ecore-application-manager-bundle": "~0.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.5.*"
     },
     "autoload": {
         "psr-4": { "CanalTP\\MttBridgeBundle\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Timetable Bridge Tests">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./vendor</directory>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
# Description

The list of calendar is not accessible by a menu anymore.

I also added dependencies to run unit tests

## How to test

Here are the following steps to test this pull request:

```
composer install
./vendor/bin/phpunit
```

And see in Timetable if the menu has disappeared

